### PR TITLE
add a subcommand to convert art19 links into embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ It assumes that:
 * all posts have `_original_post_id` post meta defined
 * all posts with a parent post have `_original_parent_id` post meta defined
 
+### fix-art19-embeds
+
 ###
 
 ## About Origins

--- a/README.md
+++ b/README.md
@@ -123,9 +123,15 @@ It assumes that:
 * all posts have `_original_post_id` post meta defined
 * all posts with a parent post have `_original_parent_id` post meta defined
 
-### fix-art19-embeds
+### fix-embeds
 
-###
+#### Usage
+
+`wp import-fixer fix-embeds --embed-url=https://art19.com`
+
+#### Description
+
+This command helps when you are importing from a source such as the Medium that embeds content from other sites.  The Medium's export function turns those embeds into text links.  This command turns those text links into plain URLs, which WordPress automatically converts to embeds.
 
 ## About Origins
 

--- a/import-fixer.php
+++ b/import-fixer.php
@@ -872,15 +872,9 @@ class Import_Fixer extends WP_CLI_Command {
 		foreach( $art_posts as $post ) {
 			$art_19_link_regex = '/<a href="(http|https\:\/\/art19\.com\/.*?)".*?<\/a>/';
 
-
-
 			if( preg_match( $art_19_link_regex, $post->post_content, $matches ) ) {
 
-				$secret = substr( str_shuffle( str_repeat( "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWWXYZ", 10 ) ), 0, 10 );
-
-				$embed = '<figure class="wp-block-embed is-type-rich is-provider-art-19"><div class="wp-block-embed__wrapper"><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="' . $matches[1] . '/embed#?secret=' . $secret . '" data-secret="' . $secret . '" width="640" height="200" scrolling="no"></iframe></div></figure>';
-
-				$new_content =  preg_replace( $art_19_link_regex, $embed, $post->post_content );
+				$new_content =  preg_replace( $art_19_link_regex, $matches[1], $post->post_content );
 
 				$updated_post = array(
 					'ID' => $post->ID,

--- a/import-fixer.php
+++ b/import-fixer.php
@@ -856,6 +856,44 @@ class Import_Fixer extends WP_CLI_Command {
 		return strlen( $b ) - strlen( $a );
 	}
 
+	/**
+	 * Turn Art19 links into embed blocks
+	 *
+	 * @subcommand fix-art-embeds
+	 */
+	public function fix_art19_embeds() {
+		$i = 0;
+		$args = array(
+			's' => 'art19',
+			'posts_per_page' => -1,
+			'post_status' => 'any',
+		);
+		$art_posts = get_posts( $args );
+		foreach( $art_posts as $post ) {
+			$art_19_link_regex = '/<a href="(http|https\:\/\/art19\.com\/.*?)".*?<\/a>/';
+
+
+
+			if( preg_match( $art_19_link_regex, $post->post_content, $matches ) ) {
+
+				$secret = substr( str_shuffle( str_repeat( "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWWXYZ", 10 ) ), 0, 10 );
+
+				$embed = '<figure class="wp-block-embed is-type-rich is-provider-art-19"><div class="wp-block-embed__wrapper"><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="' . $matches[1] . '/embed#?secret=' . $secret . '" data-secret="' . $secret . '" width="640" height="200" scrolling="no"></iframe></div></figure>';
+
+				$new_content =  preg_replace( $art_19_link_regex, $embed, $post->post_content );
+
+				$updated_post = array(
+					'ID' => $post->ID,
+					'post_content' => $new_content
+				);
+				wp_update_post( $updated_post );
+				WP_CLI::line( "Updated post " . $post->ID );
+				$i++;
+			}
+		}
+
+		WP_CLI::success( $i . ' posts updated.' );
+	}
 
 }
 

--- a/import-fixer.php
+++ b/import-fixer.php
@@ -857,7 +857,7 @@ class Import_Fixer extends WP_CLI_Command {
 	}
 
 	/**
-	 * Turn Art19 links into embed blocks
+	 * Turn links into embed blocks
 	 *
 	 * @subcommand fix-embeds
 	 * @synopsis [--embed-url=<embed-url>]
@@ -878,11 +878,11 @@ class Import_Fixer extends WP_CLI_Command {
 			$parsed_url = parse_url( $assoc_args['embed-url'] );
 			$regex_url = preg_quote( $parsed_url['host'] );
 			WP_CLI::debug( print_r( $regex_url, true ) );
-			$art_19_link_regex = '/<a href="(http|https\:\/\/' . $regex_url . '\/.*?)".*?<\/a>/';
+			$embed_regex = '/<a href="(http|https\:\/\/' . $regex_url . '\/.*?)".*?<\/a>/';
 
-			if( preg_match( $art_19_link_regex, $post->post_content, $matches ) ) {
+			if( preg_match( $embed_regex, $post->post_content, $matches ) ) {
 
-				$new_content =  preg_replace( $art_19_link_regex, $matches[1], $post->post_content );
+				$new_content =  preg_replace( $embed_regex, $matches[1], $post->post_content );
 
 				$updated_post = array(
 					'ID' => $post->ID,

--- a/import-fixer.php
+++ b/import-fixer.php
@@ -859,18 +859,26 @@ class Import_Fixer extends WP_CLI_Command {
 	/**
 	 * Turn Art19 links into embed blocks
 	 *
-	 * @subcommand fix-art-embeds
+	 * @subcommand fix-embeds
+	 * @synopsis [--embed-url=<embed-url>]
 	 */
-	public function fix_art19_embeds() {
+	public function fix_embeds( $args, $assoc_args ) {
 		$i = 0;
 		$args = array(
-			's' => 'art19',
-			'posts_per_page' => -1,
+			's' => $assoc_args['embed-url'],
+			'posts_per_page' => 5,
 			'post_status' => 'any',
+			'offset' => 15
 		);
-		$art_posts = get_posts( $args );
-		foreach( $art_posts as $post ) {
-			$art_19_link_regex = '/<a href="(http|https\:\/\/art19\.com\/.*?)".*?<\/a>/';
+		$embed_posts = get_posts( $args );
+		if( empty( $embed_posts ) ) {
+			WP_CLI::line( 'No posts found' );
+		}
+		foreach( $embed_posts as $post ) {
+			$parsed_url = parse_url( $assoc_args['embed-url'] );
+			$regex_url = preg_quote( $parsed_url['host'] );
+			WP_CLI::debug( print_r( $regex_url, true ) );
+			$art_19_link_regex = '/<a href="(http|https\:\/\/' . $regex_url . '\/.*?)".*?<\/a>/';
 
 			if( preg_match( $art_19_link_regex, $post->post_content, $matches ) ) {
 
@@ -881,7 +889,7 @@ class Import_Fixer extends WP_CLI_Command {
 					'post_content' => $new_content
 				);
 				wp_update_post( $updated_post );
-				WP_CLI::line( "Updated post " . $post->ID );
+				WP_CLI::line( 'Updated post ' . $post->ID );
 				$i++;
 			}
 		}

--- a/import-fixer.php
+++ b/import-fixer.php
@@ -866,9 +866,8 @@ class Import_Fixer extends WP_CLI_Command {
 		$i = 0;
 		$args = array(
 			's' => $assoc_args['embed-url'],
-			'posts_per_page' => 5,
+			'posts_per_page' => -1,
 			'post_status' => 'any',
-			'offset' => 15
 		);
 		$embed_posts = get_posts( $args );
 		if( empty( $embed_posts ) ) {


### PR DESCRIPTION
This PR adds a subcommand `fix-art-embeds` that finds all posts with `art19` in them, and converts links to art19.com to embeds.

This command works as expected, but it doesn't quite play nice with Gutenberg: if you take a post that has an embed generated by this command and "Convert to blocks", the embed ends up being a raw HTML block.  If you try to convert that raw HTML block to an embed block, it adds extra `<figure>` tags and gets confused.  However, everything looks fine on the front end.